### PR TITLE
Remove ruamel yaml from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,5 +67,5 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['ruamel.yaml', 'six', 'cwltool>=1.0.20170727112954'],
+    install_requires=['six', 'cwltool>=1.0.20170727112954'],
 )


### PR DESCRIPTION
Install did not work because ruamel yaml was also pulled in by cwltool, but it requires a different version